### PR TITLE
Support for protocols (https) and method to download files content.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,18 +69,18 @@
 	</dependencies>
 
 	<build>
-	<!-- 
+	
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.6.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
-			<plugin>
+			<!-- <plugin>
 				<groupId>org.jsonschema2pojo</groupId>
 				<artifactId>jsonschema2pojo-maven-plugin</artifactId>
 				<version>0.4.2</version>
@@ -97,9 +97,9 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
 		</plugins>
-		-->
+		
 	</build>
 
 </project>

--- a/src/main/java/org/mytardis/api/client/TardisClient.java
+++ b/src/main/java/org/mytardis/api/client/TardisClient.java
@@ -367,13 +367,13 @@ public class TardisClient {
 	 * 
 	 * @param id
 	 *            of the DatasetFile.
-	 * @return content of the required DatasetFile as a String.
+	 * @return binary content of the required DatasetFile.
 	 * @throws Exception
 	 *             thrown if the object is not found.
 	 */
-	public String getDatasetFileContentById(Integer id) throws Exception {
+	public byte[] getDatasetFileContentById(Integer id) throws Exception {
 		logger.debug("start!");
-		String result = null;
+		byte[] result = null;
 
 		// make request
 		WebTarget target = this.buildWebTarget(null);
@@ -384,10 +384,11 @@ public class TardisClient {
 
 		// check response
 		this.checkResponse(response);
-		result = response.readEntity(String.class);
-
+		
+		result = response.readEntity(byte[].class);
+        
 		// finished
-		return result;
+	    return result;
 	}
 	
 	/**
@@ -395,13 +396,13 @@ public class TardisClient {
 	 * 
 	 * @param uri
 	 *            of the object as a String.
-	 * @return content of the required DatasetFile as a String.
+	 * @return binary content of the required DatasetFile.
 	 * @throws Exception
 	 *             thrown if the object is not found.
 	 */
-	public String getDatasetFileContentByUri(String uri) throws Exception {
+	public byte[] getDatasetFileContentByUri(String uri) throws Exception {
 		logger.debug("start!");
-		String result = null;
+		byte[] result = null;
 
 		// make request
 		WebTarget target = this.buildWebTarget(null);
@@ -410,8 +411,9 @@ public class TardisClient {
 		
 		// check response
 		this.checkResponse(response);
-		result = response.readEntity(String.class);
-
+		
+		result = response.readEntity(byte[].class);
+        
 		// finished
 		return result;
 	}

--- a/src/main/java/org/mytardis/api/client/TardisClient.java
+++ b/src/main/java/org/mytardis/api/client/TardisClient.java
@@ -60,10 +60,13 @@ import eu.medsea.mimeutil.detector.WindowsRegistryMimeDetector;
 public class TardisClient {
 
 	public static final String API_VERSION_1 = "/api/v1";
+	public static final String URL_ENDING = "/";
+	public static final String DOWNLOAD = "download";
 	public static final String NO_DEFAULT_PROVIDED = "No default provided.";
-
+	
 	private Logger logger = LogManager.getLogger(this.getClass());
 	private Gson gson = new Gson();
+	private String protocol = "http";
 	private String address = "";
 	private String user = "";
 	private String pass = "";
@@ -86,19 +89,22 @@ public class TardisClient {
 	 *            authentication user.
 	 * @param passwd
 	 *            authentication password.
+	 * @param protocol
+	 *            protocol to use for the request.
 	 */
-	public TardisClient(String address, String username, String passwd) {
+	public TardisClient(String address, String username, String passwd, String protocol) {
 		super();
 		this.address = address;
 		this.user = username;
-		this.pass = passwd;
-
+		this.pass = passwd;		
+		this.protocol = protocol;
+		
 		// initialize date format
 		sdf.setLenient(false);
 
 		// set up tardis uri
 		try {
-			this.uri = new URI("http://" + this.address);
+			this.uri = new URI(this.protocol + "://" + this.address);
 		} catch (URISyntaxException e) {
 			logger.error("failed to create tardis url with: " + e.getMessage());
 		}
@@ -123,6 +129,20 @@ public class TardisClient {
 
 		// finished
 		return;
+	}
+	
+	/**
+	 * TardisClient default constructor.
+	 * 
+	 * @param address
+	 *            domain---or ip address---and port of the myTardis server.
+	 * @param username
+	 *            authentication user.
+	 * @param passwd
+	 *            authentication password.
+	 */
+	public TardisClient(String address, String username, String passwd) {
+		this(address, username, passwd, "http");
 	}
 
 	/***************
@@ -255,7 +275,7 @@ public class TardisClient {
 			logger.debug("target = " + target.toString());
 
 			// make request
-			Response response = target.queryParam("format", "json").request()
+			Response response = target.path(URL_ENDING).queryParam("format", "json").request()
 					.get();
 
 			// parse response
@@ -302,7 +322,8 @@ public class TardisClient {
 		WebTarget target = this.buildWebTarget(null);
 		Response response = target.path(TardisClient.API_VERSION_1)
 				.path(TardisObject.path(clazz)).path(id.toString())
-				.queryParam("format", "json").request().get();
+				.path(URL_ENDING).queryParam("format", "json")
+				.request().get();
 
 		// check response
 		this.checkResponse(response);
@@ -341,6 +362,60 @@ public class TardisClient {
 		return result;
 	}
 
+	/**
+	 * Get the content of a DatasetFile by Id
+	 * 
+	 * @param id
+	 *            of the DatasetFile.
+	 * @return content of the required DatasetFile as a String.
+	 * @throws Exception
+	 *             thrown if the object is not found.
+	 */
+	public String getDatasetFileContentById(Integer id) throws Exception {
+		logger.debug("start!");
+		String result = null;
+
+		// make request
+		WebTarget target = this.buildWebTarget(null);
+		Response response = target.path(TardisClient.API_VERSION_1)
+				.path(TardisObject.path(DatasetFile.class)).path(id.toString())
+				.path(URL_ENDING).path(DOWNLOAD).path(URL_ENDING)
+				.request().get();
+
+		// check response
+		this.checkResponse(response);
+		result = response.readEntity(String.class);
+
+		// finished
+		return result;
+	}
+	
+	/**
+	 * Get the content of a DatasetFile by URI
+	 * 
+	 * @param uri
+	 *            of the object as a String.
+	 * @return content of the required DatasetFile as a String.
+	 * @throws Exception
+	 *             thrown if the object is not found.
+	 */
+	public String getDatasetFileContentByUri(String uri) throws Exception {
+		logger.debug("start!");
+		String result = null;
+
+		// make request
+		WebTarget target = this.buildWebTarget(null);
+		Response response = target.path(uri).path(DOWNLOAD).path(URL_ENDING)
+				.request().get();
+		
+		// check response
+		this.checkResponse(response);
+		result = response.readEntity(String.class);
+
+		// finished
+		return result;
+	}
+	
 	/****************
 	 * Post Methods *
 	 ****************/
@@ -625,6 +700,14 @@ public class TardisClient {
 	 * getters and setters *
 	 ***********************/
 
+		
+	/**
+	 * @return protocol used for the requests (default http).
+	 */
+	public String getProtocol() {
+		return this.protocol;
+	}
+	
 	/**
 	 * @return URI of myTardis API.
 	 */

--- a/src/test/java/org/mytardis/api/client/TardisClientTest.java
+++ b/src/test/java/org/mytardis/api/client/TardisClientTest.java
@@ -464,4 +464,40 @@ public class TardisClientTest {
 		return;
 	}
 
+	@Test
+    public void testGetDatasetFileContent() {
+		
+		logger.debug("start!");
+		assertNotNull("TardisClient is null!", client);
+		assertNotNull("TardisClient.URI is null!", client.getURI());
+		assertEquals("TardisClient.URI not matched!", this.expectedURI, client
+				.getURI().toString());
+
+		Integer id = 1;
+		String uri = "/api/v1/dataset_file/1/";
+		
+		// retrieve the content of a Datasetfile by Id
+		String result = null;
+		try {
+			result = client.getDatasetFileContentById(id);
+		} catch (Exception e) {
+			fail("valid credentials threw an exception: " + e.getMessage());
+		}
+		assertNotNull("datasetfile content is null!", result);
+		assertFalse("datasetfile content is empty!", result.isEmpty());
+
+		
+		// retrieve the content of a Datasetfile by URI
+		result = null;
+		try {
+			result = client.getDatasetFileContentByUri(uri);
+		} catch (Exception e) {
+			fail("valid credentials threw an exception: " + e.getMessage());
+		}
+		assertNotNull("datasetfile content is null!", result);
+		assertFalse("datasetfile content is empty!", result.isEmpty());
+		
+		// finished
+		return;
+	}
 }

--- a/src/test/java/org/mytardis/api/client/TardisClientTest.java
+++ b/src/test/java/org/mytardis/api/client/TardisClientTest.java
@@ -477,14 +477,14 @@ public class TardisClientTest {
 		String uri = "/api/v1/dataset_file/1/";
 		
 		// retrieve the content of a Datasetfile by Id
-		String result = null;
+		byte[] result = null;
 		try {
 			result = client.getDatasetFileContentById(id);
 		} catch (Exception e) {
 			fail("valid credentials threw an exception: " + e.getMessage());
 		}
 		assertNotNull("datasetfile content is null!", result);
-		assertFalse("datasetfile content is empty!", result.isEmpty());
+		assertTrue("datasetfile content is empty!", result.length > 0);
 
 		
 		// retrieve the content of a Datasetfile by URI
@@ -495,7 +495,7 @@ public class TardisClientTest {
 			fail("valid credentials threw an exception: " + e.getMessage());
 		}
 		assertNotNull("datasetfile content is null!", result);
-		assertFalse("datasetfile content is empty!", result.isEmpty());
+		assertTrue("datasetfile content is empty!", result.length > 0);
 		
 		// finished
 		return;


### PR DESCRIPTION
Added a protocol property in TardisClient (default to "http") in order to enable other protocols such as HTTPS to be used (required if the MyTardis instance uses SSL).

Added methods in TardisClient to enable downloading the content of a Datasetfile, either by ID or by URI.

Uncommented the "plugins" section in pom.xml and updated to the latest Maven compiler version in order to use Java 8 features.